### PR TITLE
Update to Report Button

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -25,7 +25,6 @@
             android:layout_width="503dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:onClick="reportFire"
             android:text="@string/report_local_fire"
             android:visibility="visible" />
 


### PR DESCRIPTION
When markers are created using the report button, there is now an explanation via Toast to tell the user to hold down the fire icon to move it. After clicking "Finished Placing Marker", the icon's location is locked, and it's color changed to represent a permanent icon.

I'd like to have a dialog pop up now for the user to enter a description. Hopeful to have this before this sprint is over.