### PR TITLE
Added Cancel Button + Other Minor Improvements / Edge Case Fix

### DIFF
--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -15,9 +15,9 @@
         android:layout_height="0dp"
         map:layout_constraintBottom_toTopOf="@+id/report"
         map:layout_constraintEnd_toEndOf="parent"
+        map:layout_constraintHorizontal_bias="1.0"
         map:layout_constraintStart_toStartOf="parent"
         map:layout_constraintTop_toTopOf="parent" />
-
 
     <Button
         android:id="@+id/report"
@@ -41,5 +41,16 @@
         map:layout_constraintStart_toStartOf="parent"
         map:layout_constraintTop_toBottomOf="@+id/map" />
 
+    <Button
+        android:id="@+id/cancel_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="16dp"
+        android:text="@string/cancel_button_text"
+        map:backgroundTint="#E13434"
+        map:layout_constraintStart_toStartOf="@+id/map"
+        map:layout_constraintTop_toTopOf="@+id/map" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="title_activity_maps">Fire Map</string>
     <string name="report_local_fire">Report Local Fire</string>
     <string name="finished_placing_marker">Finished Placing Marker</string>
+    <string name="cancel_button_text">Cancel</string>
 </resources>


### PR DESCRIPTION
Added cancel button in case user accidentally clicks report button
Added more toasts on user action to show responsiveness in the program
Toasts get canceled if another one is to be activated while the first one is still up
Edge case of fire not moved fixed, set coords variable to California coords in advance of them being set by the moved icon
User-movable icon made bigger for visibility sake
When icon placed, screen used to shrink in size because the button was set to '.gone'. Fixed to '.invisible'.