### PR TITLE
Cancel Button Wasn't Disappearing Post Successful Marker Placement

### DIFF
--- a/app/src/main/java/me/techchrism/firetracker/MapsActivity.kt
+++ b/app/src/main/java/me/techchrism/firetracker/MapsActivity.kt
@@ -106,6 +106,8 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
             newMarker.remove()
             // Set the button to gone while the user sets the location of the marker
             markerPlacedButton.visibility = View.GONE
+            // Hide the cancel placement button
+            cancelPlacementButton.visibility = View.GONE
             // Return the report button
             reportButton.visibility = View.VISIBLE
         }


### PR DESCRIPTION
Cancel button needed to be removed after a marker was successfully replaced, only to reappear once user selects report button again.