### PR TITLE
add support for individual deletion

### DIFF
--- a/app/src/main/java/me/techchrism/firetracker/MapsActivity.kt
+++ b/app/src/main/java/me/techchrism/firetracker/MapsActivity.kt
@@ -61,7 +61,7 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         }
 
         // Set up the network manager
-        networkManager = NetworkManager(this)
+        networkManager = NetworkManager(this, appID)
         networkManager.onError = { message ->
             Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/java/me/techchrism/firetracker/MapsActivity.kt
+++ b/app/src/main/java/me/techchrism/firetracker/MapsActivity.kt
@@ -209,8 +209,9 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
             }
         })
 
-        // Set up new marker callback
+        // Set up marker callbacks
         networkManager.onNewFire = this::addFireMarker
+        networkManager.onFireRemoved = this::removeFireMarker
         // If fires have already been loaded, add them to the map
         if(networkManager.incidents.size > 0) {
             for(fireData: FireData in networkManager.incidents.values) {
@@ -284,6 +285,14 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         val marker = mMap.addMarker(markerOptions)
         marker.tag = fireData
         fireMarkers[fireData.uniqueID] = marker
+    }
+
+    private fun removeFireMarker(fireData: FireData) {
+        if (!this::mMap.isInitialized || !fireMarkers.containsKey(fireData.uniqueID)) {
+            return
+        }
+        fireMarkers[fireData.uniqueID]?.remove()
+        fireMarkers.remove(fireData.uniqueID)
     }
 
     /**

--- a/app/src/main/java/me/techchrism/firetracker/NetworkManager.kt
+++ b/app/src/main/java/me/techchrism/firetracker/NetworkManager.kt
@@ -47,7 +47,8 @@ class NetworkManager
             report.getDouble("latitude"),
             report.getDouble("longitude"),
             format.parse(report.getString("reported"))!!,
-            report.getBoolean("canRemove")
+            report.getBoolean("canRemove"),
+            report.getString("_id")
         )
     }
 

--- a/app/src/main/java/me/techchrism/firetracker/NetworkManager.kt
+++ b/app/src/main/java/me/techchrism/firetracker/NetworkManager.kt
@@ -105,6 +105,19 @@ class NetworkManager
     }
 
     /**
+     * Remove a fire
+     */
+    private fun removeFire(data: FireData) {
+        if(!incidents.containsKey(data.uniqueID)) {
+            return
+        }
+        incidents.remove(data.uniqueID)
+        if (this::onFireRemoved.isInitialized) {
+            onFireRemoved(data)
+        }
+    }
+
+    /**
      * Loads reported fire data from the FireTracker server
      */
     private fun loadReportedFireData() {
@@ -182,6 +195,11 @@ class NetworkManager
                         val fireData = loadReportedFireData(body.getJSONObject("data"))
                         mainHandler.post {
                             addFire(fireData)
+                        }
+                    } else if (body.getString("action") == "removed") {
+                        val fireData = loadReportedFireData(body.getJSONObject("data"))
+                        mainHandler.post {
+                            removeFire(fireData)
                         }
                     }
                 }

--- a/app/src/main/java/me/techchrism/firetracker/NetworkManager.kt
+++ b/app/src/main/java/me/techchrism/firetracker/NetworkManager.kt
@@ -19,7 +19,7 @@ import java.util.*
 
 
 class NetworkManager
-    (context: Context) {
+    (context: Context, private val userID: UUID) {
     private var requestQueue: RequestQueue = Volley.newRequestQueue(context)
 
     var incidents: HashMap<UUID, FireData> = HashMap()
@@ -46,7 +46,8 @@ class NetworkManager
             id,
             report.getDouble("latitude"),
             report.getDouble("longitude"),
-            format.parse(report.getString("reported"))!!
+            format.parse(report.getString("reported"))!!,
+            report.getBoolean("canRemove")
         )
     }
 
@@ -123,7 +124,7 @@ class NetworkManager
     private fun loadReportedFireData() {
         val reportedFireDataRequest = JsonArrayRequest(
             Request.Method.GET,
-            "https://firetracker.techchrism.me/markers",
+            "https://firetracker.techchrism.me/markers?id=${userID}",
             null,
             { response ->
                 // Iterate through the reports in the api

--- a/app/src/main/java/me/techchrism/firetracker/NetworkManager.kt
+++ b/app/src/main/java/me/techchrism/firetracker/NetworkManager.kt
@@ -94,6 +94,24 @@ class NetworkManager
     }
 
     /**
+     * Remove a fire by id
+     */
+    fun removeFire(id: String) {
+        val removeRequest = JsonObjectRequest(
+            Request.Method.DELETE,
+            "https://firetracker.techchrism.me/markers/${id}?id=${userID}",
+            null,
+            { response ->
+                //TODO evaluate removing from initial request vs waiting for websocket
+            },
+            { error ->
+                handleNetworkError(error, "Error while removing: ")
+            }
+        )
+        requestQueue.add(removeRequest)
+    }
+
+    /**
      * Add a fire if it doesn't already exist
      */
     private fun addFire(data: FireData) {

--- a/app/src/main/java/me/techchrism/firetracker/firedata/ReportedFireData.kt
+++ b/app/src/main/java/me/techchrism/firetracker/firedata/ReportedFireData.kt
@@ -6,5 +6,6 @@ data class ReportedFireData (
     override var uniqueID: UUID,
     override val latitude: Double,
     override val longitude: Double,
-    val reported: Date
+    val reported: Date,
+    val canRemove: Boolean
 ) : FireData

--- a/app/src/main/java/me/techchrism/firetracker/firedata/ReportedFireData.kt
+++ b/app/src/main/java/me/techchrism/firetracker/firedata/ReportedFireData.kt
@@ -7,5 +7,6 @@ data class ReportedFireData (
     override val latitude: Double,
     override val longitude: Double,
     val reported: Date,
-    val canRemove: Boolean
+    val canRemove: Boolean,
+    val internalID: String
 ) : FireData


### PR DESCRIPTION
ReportedFireData object now has fields "canRemove" and "internalID"
Calling "removeFire" from NetworkManager with the internalID will remove the fire if "canRemove" is true